### PR TITLE
docs: add local demo workspace note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Component docs: [doc/](doc/). Crash guard guide: [doc/MKCrashGuard.md](doc/MKCra
 $ pod repo update
 ```
 
+## Local Demo
 
+After `pod install`, open `Example/MKAppKit.xcworkspace` in Xcode to browse component demos.
+Email autocomplete docs: [doc/MKDropdownMailTF.md](doc/MKDropdownMailTF.md).
 
 


### PR DESCRIPTION
Append Local Demo section with Xcode workspace path and MKDropdownMailTF doc link. README only.

Made with [Cursor](https://cursor.com)